### PR TITLE
Feature/perturb binary

### DIFF
--- a/scruf/agent/__init__.py
+++ b/scruf/agent/__init__.py
@@ -6,4 +6,4 @@ from .compatibility_metric import CompatibilityMetric, CompatibilityMetricFactor
 from .user_agent_compatibility import ContextCompatibilityMetric
 #from .value_scorer import FixedValueChoiceScorer
 from .preference_function import PreferenceFunction, PreferenceFunctionFactory
-from .binary_preference import BinaryPreferenceFunction
+from .binary_preference import BinaryPreferenceFunction, PerturbedBinaryPreferenceFunction

--- a/scruf/agent/binary_preference.py
+++ b/scruf/agent/binary_preference.py
@@ -1,6 +1,7 @@
 from .preference_function import PreferenceFunctionFactory, PreferenceFunction
 import scruf
 import copy
+import random
 from scruf.util import ResultList
 
 
@@ -34,7 +35,24 @@ class BinaryPreferenceFunction(PreferenceFunction):
         return rec_list
 
 
+# Adds a random value to the binary rescoring effectively making it a total order instead of a partial order.
+class PerturbedBinaryPreferenceFunction(BinaryPreferenceFunction):
+    def __init__(self):
+        super().__init__()
+
+    def __str__ (self):
+        prot_feature = self.get_property('protected_feature')
+        delta = self.get_property('delta')
+        return f"PerturbedPreferenceFunction: protected feature = {prot_feature}, delta = {delta}"
+
+    def compute_preferences(self, recommendations: ResultList) -> ResultList:
+        rand: random.Random = scruf.Scruf.ScrufState.rand
+        delta = float(self.get_property('delta'))
+        rec_list = super().compute_preferences(recommendations)
+        rec_list.rescore(lambda entry: entry.score + delta * rand.gauss(0, 0.1))
+
 # Register the mechanisms created above
-pfunc_specs = [("binary_preference", BinaryPreferenceFunction)]
+pfunc_specs = [("binary_preference", BinaryPreferenceFunction),
+               ("perturbed_binary", PerturbedBinaryPreferenceFunction)]
 
 PreferenceFunctionFactory.register_preference_functions(pfunc_specs)

--- a/scruf/agent/binary_preference.py
+++ b/scruf/agent/binary_preference.py
@@ -46,10 +46,11 @@ class PerturbedBinaryPreferenceFunction(BinaryPreferenceFunction):
         return f"PerturbedPreferenceFunction: protected feature = {prot_feature}, delta = {delta}"
 
     def compute_preferences(self, recommendations: ResultList) -> ResultList:
-        rand: random.Random = scruf.Scruf.ScrufState.rand
+        rand: random.Random = scruf.Scruf.state.rand
         delta = float(self.get_property('delta'))
         rec_list = super().compute_preferences(recommendations)
         rec_list.rescore(lambda entry: entry.score + delta * rand.gauss(0, 0.1))
+        return rec_list
 
 # Register the mechanisms created above
 pfunc_specs = [("binary_preference", BinaryPreferenceFunction),

--- a/tests/agent/test_preference_function.py
+++ b/tests/agent/test_preference_function.py
@@ -1,0 +1,116 @@
+import unittest
+import tempfile
+import pathlib
+import toml
+import random
+from icecream import ic
+from scruf.agent import BinaryPreferenceFunction, PerturbedBinaryPreferenceFunction
+from scruf.util import ResultList
+from scruf.data import ItemFeatureData
+import scruf
+
+TEST_FEATURE_DATA = '''
+i1, feature1, a
+i1, feature2, 1.5
+i1, feature3, 1
+i2, feature1, b
+i2, feature2, 3.5
+i2, feature3, 1
+i3, feature1, a
+i3, feature2, -1.2
+'''
+
+TEST_FEATURE_FILE = "test-features.csv"
+
+TEST_FEATURE_CONFIG = f'''
+[location]
+path = "."
+
+[data]
+feature_filename = "test-features.csv"
+
+[feature]
+
+[feature.feature1]
+name = "Protected values"
+protected_feature = "feature1"
+protected_values = ["a", "c"]
+
+[feature.feature3]
+name = "Protected binary"
+protected_feature = "feature3"
+protected_values = 1
+'''
+
+TEST_PROPERTIES = {
+    "feature": "Protected values",
+    "delta": 0.5
+}
+
+RESULT_TRIPLES1 = [('u1', 'i1', '3.5'),
+                  ('u1', 'i2', '2.5'), # unprotected
+                  ('u1', 'i3', '1.5'),
+                  ]
+
+
+class PreferenceFunctionTestCase(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.temp_dir = tempfile.TemporaryDirectory()
+        # Get the path to the temporary directory
+        self.temp_dir_path = pathlib.Path(self.temp_dir.name)
+        with open(self.temp_dir_path / TEST_FEATURE_FILE, 'w') as feature_file:
+            feature_file.write(TEST_FEATURE_DATA)
+
+        self.config = toml.loads(TEST_FEATURE_CONFIG)
+
+    def tearDown(self):
+        # Delete the temporary directory and all its contents
+        self.temp_dir.cleanup()
+
+    def test_binary_preference(self):
+        if_data = ItemFeatureData()
+        self.config['location']['path'] = self.temp_dir_path
+        if_data.setup(self.config)
+
+        scruf.Scruf.state = scruf.Scruf.ScrufState(None)
+        scruf.Scruf.state.item_features = if_data
+
+        bpf = BinaryPreferenceFunction()
+        bpf.setup(TEST_PROPERTIES)
+        rl1 = ResultList()
+        rl1.setup(RESULT_TRIPLES1)
+
+        rl_output = bpf.compute_preferences(rl1)
+        entries = rl_output.get_results()
+
+        self.assertAlmostEqual(0.5, entries[0].score)  # add assertion here
+        self.assertAlmostEqual(0.0, entries[2].score)
+
+    def test_perturbed_binary(self):
+        if_data = ItemFeatureData()
+        self.config['location']['path'] = self.temp_dir_path
+        if_data.setup(self.config)
+
+        scruf.Scruf.state = scruf.Scruf.ScrufState(None)
+        scruf.Scruf.state.item_features = if_data
+        scruf.Scruf.state.rand = random.Random(230629)
+
+        ppf = PerturbedBinaryPreferenceFunction()
+        ppf.setup(TEST_PROPERTIES)
+        rl1 = ResultList()
+        rl1.setup(RESULT_TRIPLES1)
+
+        rl_output = ppf.compute_preferences(rl1)
+        entries = rl_output.get_results()
+        top_entry = entries[0]
+        self.assertEqual('i3', top_entry.item)
+        self.assertAlmostEqual(0.533, top_entry.score, delta=0.001)
+
+        last_entry = entries[2]
+        self.assertEqual('i2', last_entry.item)
+        self.assertAlmostEqual(-0.018, last_entry.score, delta=0.001)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scruf_test_suite.py
+++ b/tests/scruf_test_suite.py
@@ -3,6 +3,7 @@ import unittest
 from agent.test_fairness_agents import AgentTestCase
 from agent.test_fairness_metric import FairnessMetricTestCase
 from agent.test_compatibility_metric import CompatibilityMetricTestCase
+from agent.test_preference_function import PreferenceFunctionTestCase
 from allocation.test_allocation_mechanism import AllocationMechanismTestCase
 from choice.test_choice_mechanism import ChoiceMechanismTestCase
 from choice.test_whalrus_wrapper import WhalrusWrapperTestCase
@@ -27,6 +28,8 @@ def suite():
     suite.addTest(metric_tests)
     compat_test = unittest.defaultTestLoader.loadTestsFromTestCase(CompatibilityMetricTestCase)
     suite.addTest(compat_test)
+    pref_test = unittest.defaultTestLoader.loadTestsFromTestCase(CompatibilityMetricTestCase)
+    suite.addTest(pref_test)
     alloc_test = unittest.defaultTestLoader.loadTestsFromTestCase(AllocationMechanismTestCase)
     suite.addTest(alloc_test)
     choice_test = unittest.defaultTestLoader.loadTestsFromTestCase(ChoiceMechanismTestCase)


### PR DESCRIPTION
Implementation of the perturbed binary preference function. Allows binary preferences to (stochastically) generate total orders by adding randomness to the scores.